### PR TITLE
server: fix registration edge case check when the address is already registered

### DIFF
--- a/src/server/api-register.js
+++ b/src/server/api-register.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import fetch from 'node-fetch';
+import { checkIfRegistered } from '../contracts/lite-register.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = path.join(__dirname, '../..');
@@ -30,12 +31,18 @@ function parseSignFile() {
 
 async function registerNode() {
   try {
-    // Read transaction hash
-    const TX_HASH = fs.readFileSync(TX_HASH_PATH, 'utf-8').trim();
-    
+
     // Parse sign file
     const { nodeId, signerAddress, timestamp, signature } = parseSignFile();
 
+    if (await checkIfRegistered(signerAddress)) {
+      console.log("ℹ️ This address is already registered onchain, no need to check.");
+      return;
+    }
+
+    // Read transaction hash
+    const TX_HASH = fs.readFileSync(TX_HASH_PATH, 'utf-8').trim();
+    
     const payload = {
       wallet: signerAddress,
       nodeId: nodeId,


### PR DESCRIPTION
this is an edge case - if the wallet is already registered and say the node is moved to some other machine or if the repo is deleted and started all over again then there wouldn't be any file at ../node-lite/register-tx-hash.txt because contracts/lite-register.js would return from `if (await checkIfRegistered(signerAddress))` condition and would not write anything to txHashPath in `fs.writeFileSync(txHashPath, tx.hash);`. So now the server code checks if the signer address is already registered and thus prevents the error caused in `node-lite/register.js`'s `Step:5 console.log(orange.bold('\n🔶 Step 5: Server Registration'))`.